### PR TITLE
fix: 修复了 v0.9.1 中的 panic: send on closed channel问题

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,12 +6,14 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/open-dingtalk/dingtalk-stream-sdk-go/card"
 	"io"
 	"net/http"
 	"net/url"
 	"sync"
 	"time"
+
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/card"
+	"golang.org/x/sync/errgroup"
 
 	"github.com/gorilla/websocket"
 
@@ -144,28 +146,33 @@ func (cli *StreamClient) processLoop() {
 	readChan := make(chan []byte)
 	pongChan := make(chan struct{})
 	closeChan := make(chan struct{})
-	defer func() { close(closeChan) }()
-	defer func() { close(pongChan) }()
-	defer func() { close(readChan) }()
+	var wg errgroup.Group
+
+	defer func() {
+		wg.Wait()
+		close(closeChan)
+		close(pongChan)
+		close(readChan)
+	}()
 
 	cli.conn.SetPongHandler(func(appData string) error {
 		pongChan <- struct{}{}
 		return nil
 	})
 	//开始启动协程读数据
-	go func() {
+	wg.Go(func() error {
 		for {
 			messageType, message, err := cli.conn.ReadMessage()
 			if err != nil {
 				logger.GetLogger().Errorf("connection process read message error: messageType=[%d] message=[%s] error=[%s]", messageType, string(message), err)
 				closeChan <- struct{}{}
-				return
+				return nil
 			}
 			if messageType == websocket.TextMessage {
 				readChan <- message
 			}
 		}
-	}()
+	})
 
 	//循环处理事件
 	for {
@@ -185,16 +192,16 @@ func (cli *StreamClient) processLoop() {
 				logger.GetLogger().Errorf("connection write ping message error: error=[%s]", e)
 				return
 			}
-			go func() {
+			wg.Go(func() error {
 				select {
 				case <-pongChan:
-					return
+					return nil
 				case <-time.After(5 * time.Second):
 					logger.GetLogger().Errorf("ping time out, connection is closing")
 					closeChan <- struct{}{}
-					return
+					return nil
 				}
-			}()
+			})
 		case <-closeChan:
 			return
 		}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-dingtalk/dingtalk-stream-sdk-go
 
-go 1.18
+go 1.24.0
 
 require (
 	github.com/google/uuid v1.3.0
@@ -11,5 +11,6 @@ require (
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sync v0.19.0
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
+golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
### 问题
在 v0.9.1 版本中，长时间运行会出现panic: send on closed channel导致崩溃

### 改动
- 等待消息发送完成后再关闭channel

### 测试
- 已本地验证通过
- 单元测试全部通过