### PR TITLE
fix: 使用 context 替代 closeChan 修复 processLoop 中 send on closed channel …

### DIFF
--- a/card/handler.go
+++ b/card/handler.go
@@ -24,7 +24,10 @@ func (h *DefaultCardCallbackFrameHandler) OnEventReceived(ctx context.Context, d
 	if err != nil {
 		return nil, err
 	}
-	json.Unmarshal([]byte(msgData.Content), &msgData.CardActionData)
+	err = json.Unmarshal([]byte(msgData.Content), &msgData.CardActionData)
+	if err != nil {
+		return nil, err
+	}
 
 	if h.defaultHandler == nil {
 		return payload.NewDataFrameResponse(payload.DataFrameResponseStatusCodeKHandlerNotFound), nil

--- a/client/client.go
+++ b/client/client.go
@@ -141,33 +141,47 @@ func (cli *StreamClient) processLoop() {
 		return
 	}
 
+	// 使用 context 替代 closeChan，避免子 goroutine 向已关闭的 channel 发送导致 panic
+	// see: https://github.com/open-dingtalk/dingtalk-stream-sdk-go/issues/27
+	// see: https://github.com/open-dingtalk/dingtalk-stream-sdk-go/issues/28
+	// see: https://github.com/open-dingtalk/dingtalk-stream-sdk-go/issues/32
+	loopCtx, cancelLoop := context.WithCancel(context.Background())
 	readChan := make(chan []byte)
 	pongChan := make(chan struct{})
-	closeChan := make(chan struct{})
-	defer func() { close(closeChan) }()
-	defer func() { close(pongChan) }()
-	defer func() { close(readChan) }()
+	defer func() {
+		cancelLoop()
+		close(pongChan)
+	}()
 
 	cli.conn.SetPongHandler(func(appData string) error {
-		pongChan <- struct{}{}
+		select {
+		case pongChan <- struct{}{}:
+		case <-loopCtx.Done():
+		}
 		return nil
 	})
-	//开始启动协程读数据
+
+	// 读消息 goroutine，退出时关闭 readChan 通知主循环
 	go func() {
+		defer close(readChan)
 		for {
 			messageType, message, err := cli.conn.ReadMessage()
 			if err != nil {
 				logger.GetLogger().Errorf("connection process read message error: messageType=[%d] message=[%s] error=[%s]", messageType, string(message), err)
-				closeChan <- struct{}{}
+				cancelLoop()
 				return
 			}
 			if messageType == websocket.TextMessage {
-				readChan <- message
+				select {
+				case readChan <- message:
+				case <-loopCtx.Done():
+					return
+				}
 			}
 		}
 	}()
 
-	//循环处理事件
+	// 主事件循环
 	for {
 		timer := time.NewTimer(cli.keepAliveIdle)
 		select {
@@ -191,11 +205,14 @@ func (cli *StreamClient) processLoop() {
 					return
 				case <-time.After(5 * time.Second):
 					logger.GetLogger().Errorf("ping time out, connection is closing")
-					closeChan <- struct{}{}
+					cancelLoop()
+					return
+				case <-loopCtx.Done():
 					return
 				}
 			}()
-		case <-closeChan:
+		case <-loopCtx.Done():
+			timer.Stop()
 			return
 		}
 	}

--- a/client/client.go
+++ b/client/client.go
@@ -150,7 +150,6 @@ func (cli *StreamClient) processLoop() {
 	pongChan := make(chan struct{})
 	defer func() {
 		cancelLoop()
-		close(pongChan)
 	}()
 
 	cli.conn.SetPongHandler(func(appData string) error {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,7 +1,13 @@
 package client
 
 import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
 )
 
 /**
@@ -16,6 +22,57 @@ func TestDingtalkOpenStreamClient_Start(t *testing.T) {
 }
 
 func TestDingtalkOpenStreamClient_processDataFrame(t *testing.T) {
+}
+
+func TestDingtalkOpenStreamClient_processLoop_PongHandlerAfterExitDoesNotPanic(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade websocket: %v", err)
+			return
+		}
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("dial websocket: %v", err)
+	}
+
+	cli := &StreamClient{
+		conn:          conn,
+		AutoReconnect: false,
+		keepAliveIdle: time.Hour,
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		cli.processLoop()
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("processLoop did not exit")
+	}
+
+	pongHandler := conn.PongHandler()
+	for i := 0; i < 100; i++ {
+		func() {
+			defer func() {
+				if err := recover(); err != nil {
+					t.Fatalf("pong handler panicked after processLoop exit: %v", err)
+				}
+			}()
+			if err := pongHandler(""); err != nil {
+				t.Fatalf("pong handler returned error: %v", err)
+			}
+		}()
+	}
 }
 
 func TestDingtalkOpenStreamClient_Close(t *testing.T) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -24,7 +24,9 @@ func TestDingtalkOpenStreamClient_Start(t *testing.T) {
 func TestDingtalkOpenStreamClient_processDataFrame(t *testing.T) {
 }
 
-func TestDingtalkOpenStreamClient_processLoop_PongHandlerAfterExitDoesNotPanic(t *testing.T) {
+func newTestWebsocketConn(t *testing.T, serverHandler func(*websocket.Conn)) *websocket.Conn {
+	t.Helper()
+
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
@@ -32,20 +34,30 @@ func TestDingtalkOpenStreamClient_processLoop_PongHandlerAfterExitDoesNotPanic(t
 			t.Errorf("upgrade websocket: %v", err)
 			return
 		}
-		_ = conn.Close()
+		go serverHandler(conn)
 	}))
-	defer server.Close()
 
 	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
 	if err != nil {
+		server.Close()
 		t.Fatalf("dial websocket: %v", err)
 	}
+	t.Cleanup(func() {
+		_ = conn.Close()
+		server.Close()
+	})
+
+	return conn
+}
+
+func runProcessLoop(t *testing.T, conn *websocket.Conn, keepAliveIdle time.Duration) <-chan struct{} {
+	t.Helper()
 
 	cli := &StreamClient{
 		conn:          conn,
 		AutoReconnect: false,
-		keepAliveIdle: time.Hour,
+		keepAliveIdle: keepAliveIdle,
 	}
 
 	done := make(chan struct{})
@@ -53,12 +65,55 @@ func TestDingtalkOpenStreamClient_processLoop_PongHandlerAfterExitDoesNotPanic(t
 		defer close(done)
 		cli.processLoop()
 	}()
+	return done
+}
+
+func waitProcessLoopExit(t *testing.T, done <-chan struct{}, timeout time.Duration) {
+	t.Helper()
 
 	select {
 	case <-done:
-	case <-time.After(time.Second):
+	case <-time.After(timeout):
 		t.Fatal("processLoop did not exit")
 	}
+}
+
+func TestDingtalkOpenStreamClient_processLoop_ReadErrorCancelsLoop(t *testing.T) {
+	conn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		_ = conn.Close()
+	})
+
+	done := runProcessLoop(t, conn, time.Hour)
+
+	waitProcessLoopExit(t, done, time.Second)
+}
+
+func TestDingtalkOpenStreamClient_processLoop_PingTimeoutCancelsLoop(t *testing.T) {
+	conn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		conn.SetPingHandler(func(string) error {
+			return nil
+		})
+		for {
+			if _, _, err := conn.NextReader(); err != nil {
+				_ = conn.Close()
+				return
+			}
+		}
+	})
+
+	done := runProcessLoop(t, conn, 10*time.Millisecond)
+
+	waitProcessLoopExit(t, done, 6*time.Second)
+}
+
+func TestDingtalkOpenStreamClient_processLoop_PongHandlerAfterExitDoesNotPanic(t *testing.T) {
+	conn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		_ = conn.Close()
+	})
+
+	done := runProcessLoop(t, conn, time.Hour)
+
+	waitProcessLoopExit(t, done, time.Second)
 
 	pongHandler := conn.PongHandler()
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
…panic

子 goroutine（读消息、ping 超时）在 processLoop 退出后仍可能向已关闭的
closeChan 发送数据，导致 panic: send on closed channel。

使用 context.WithCancel 替代 closeChan 作为关闭信号机制，所有子 goroutine 通过 cancelLoop() 通知退出，主循环监听 loopCtx.Done()，彻底消除竞态。

Fixes: #27, #28, #32