### PR TITLE
fix: stabilize stream keepAlive to stop false ping timeouts

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,22 +16,33 @@ jobs:
     timeout-minutes: 10
     strategy:
       matrix:
-        go-version: ['1.18.x', '1.20.3']
+        go-version: ['1.18.x', '1.20.x', '1.26.x']
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go Environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.go-version }}
       - name: Run Tests
         run: go test ./...
+  race:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Go Environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+      - name: Run Race Tests
+        run: go test -race ./...
   gofmt:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go Environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20.3'
       - name: Run gofmt Check
@@ -47,16 +58,16 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Setup Go Environment
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: '1.20.3'
       - name: Install jq
         run: sudo apt install -y jq
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '20'
       - name: Download golangci-lint
         run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.54.2
       - name: Run Golang Linters

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,6 +11,20 @@ on:
       - release/**
 permissions: read-all
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      matrix:
+        go-version: ['1.18.x', '1.20.3']
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Go Environment
+        uses: actions/setup-go@v3
+        with:
+          go-version: ${{ matrix.go-version }}
+      - name: Run Tests
+        run: go test ./...
   gofmt:
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/chatbot/model.go
+++ b/chatbot/model.go
@@ -32,6 +32,7 @@ type BotCallbackDataModel struct {
 	IsInAtList                bool                         `json:"isInAtList"`
 	SessionWebhook            string                       `json:"sessionWebhook"`
 	Text                      BotCallbackDataTextModel     `json:"text"`
+	RobotCode                 string                       `json:"robotCode"`
 	Msgtype                   string                       `json:"msgtype"`
 	Content                   interface{}                  `json:"content"`
 }

--- a/chatbot/model_test.go
+++ b/chatbot/model_test.go
@@ -1,0 +1,26 @@
+package chatbot
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBotCallbackDataModel_UnmarshalRobotCode(t *testing.T) {
+	raw := `{
+		"conversationId":"cidxxx",
+		"msgId":"msgxxx",
+		"senderNick":"Alice",
+		"msgtype":"text",
+		"robotCode":"ding0f4lethz0fonxvz6",
+		"text":{"content":"hello"}
+	}`
+
+	var model BotCallbackDataModel
+	require.NoError(t, json.Unmarshal([]byte(raw), &model))
+	assert.Equal(t, "ding0f4lethz0fonxvz6", model.RobotCode)
+	assert.Equal(t, "hello", model.Text.Content)
+	assert.Equal(t, "text", model.Msgtype)
+}

--- a/client/client.go
+++ b/client/client.go
@@ -47,14 +47,18 @@ type StreamClient struct {
 	openApiHost   string
 	proxy         string
 	keepAliveIdle time.Duration
+	writeTimeout  time.Duration
 }
 
 type connectionContextKey struct{}
+
+const defaultWriteTimeout = 5 * time.Second
 
 func NewStreamClient(options ...ClientOption) *StreamClient {
 	lifecycleCtx, cancel := context.WithCancel(context.Background())
 	cli := &StreamClient{
 		keepAliveIdle: 120 * time.Second,
+		writeTimeout:  defaultWriteTimeout,
 		lifecycleCtx:  lifecycleCtx,
 		cancel:        cancel,
 	}
@@ -273,7 +277,7 @@ func (cli *StreamClient) processConnection(conn *websocket.Conn, keepAliveIdle t
 			default:
 			}
 
-			if err := cli.writeMessageToConnection(conn, websocket.PingMessage, nil); err != nil {
+			if err := cli.writeControlToConnection(conn, websocket.PingMessage, nil); err != nil {
 				logger.GetLogger().Errorf("connection write ping message error: error=[%s]", err)
 				return
 			}
@@ -332,7 +336,21 @@ func (cli *StreamClient) writeMessageToConnection(conn *websocket.Conn, messageT
 
 	cli.writeMutex.Lock()
 	defer cli.writeMutex.Unlock()
+	if err := conn.SetWriteDeadline(time.Now().Add(cli.getWriteTimeout())); err != nil {
+		return err
+	}
 	return conn.WriteMessage(messageType, data)
+}
+
+func (cli *StreamClient) writeControlToConnection(conn *websocket.Conn, messageType int, data []byte) error {
+	if conn == nil {
+		return errors.New("disconnected")
+	}
+
+	// Gorilla permits WriteControl concurrently with data writes. Keeping
+	// heartbeat control frames out of writeMutex ensures a blocked application
+	// write cannot prevent keepalive from timing out and closing the connection.
+	return conn.WriteControl(messageType, data, time.Now().Add(cli.getWriteTimeout()))
 }
 
 func (cli *StreamClient) writeJSON(v interface{}) error {
@@ -350,7 +368,17 @@ func (cli *StreamClient) writeJSONToConnection(conn *websocket.Conn, v interface
 
 	cli.writeMutex.Lock()
 	defer cli.writeMutex.Unlock()
+	if err := conn.SetWriteDeadline(time.Now().Add(cli.getWriteTimeout())); err != nil {
+		return err
+	}
 	return conn.WriteJSON(v)
+}
+
+func (cli *StreamClient) getWriteTimeout() time.Duration {
+	if cli.writeTimeout <= 0 {
+		return defaultWriteTimeout
+	}
+	return cli.writeTimeout
 }
 
 func (cli *StreamClient) processDataFrame(rawData []byte) {

--- a/client/client.go
+++ b/client/client.go
@@ -136,38 +136,47 @@ func (cli *StreamClient) processLoop() {
 		}
 	}()
 
-	if cli.conn == nil {
+	cli.mutex.Lock()
+	conn := cli.conn
+	keepAliveIdle := cli.keepAliveIdle
+	cli.mutex.Unlock()
+
+	if conn == nil {
 		logger.GetLogger().Errorf("connection process connect nil, maybe disconnected.")
 		return
 	}
 
-	// 使用 context 替代 closeChan，避免子 goroutine 向已关闭的 channel 发送导致 panic
+	// Use context instead of closeChan to avoid send-on-closed-channel panic.
 	// see: https://github.com/open-dingtalk/dingtalk-stream-sdk-go/issues/27
 	// see: https://github.com/open-dingtalk/dingtalk-stream-sdk-go/issues/28
 	// see: https://github.com/open-dingtalk/dingtalk-stream-sdk-go/issues/32
 	loopCtx, cancelLoop := context.WithCancel(context.Background())
-	readChan := make(chan []byte)
-	pongChan := make(chan struct{})
-	defer func() {
-		cancelLoop()
-	}()
+	defer cancelLoop()
 
-	cli.conn.SetPongHandler(func(appData string) error {
+	// Buffered + non-blocking send: late/extra pongs must never block ReadMessage.
+	pongReceived := make(chan struct{}, 1)
+	conn.SetPongHandler(func(string) error {
 		select {
-		case pongChan <- struct{}{}:
-		case <-loopCtx.Done():
+		case pongReceived <- struct{}{}:
+		default:
 		}
 		return nil
 	})
 
+	readChan := make(chan []byte)
 	// 读消息 goroutine，退出时关闭 readChan 通知主循环
 	go func() {
-		defer close(readChan)
+		defer func() {
+			if err := recover(); err != nil {
+				logger.GetLogger().Errorf("connection read loop panic, error=[%s]", err)
+			}
+			close(readChan)
+			cancelLoop()
+		}()
 		for {
-			messageType, message, err := cli.conn.ReadMessage()
+			messageType, message, err := conn.ReadMessage()
 			if err != nil {
 				logger.GetLogger().Errorf("connection process read message error: messageType=[%d] message=[%s] error=[%s]", messageType, string(message), err)
-				cancelLoop()
 				return
 			}
 			if messageType == websocket.TextMessage {
@@ -180,41 +189,92 @@ func (cli *StreamClient) processLoop() {
 		}
 	}()
 
-	// 主事件循环
+	const pingWait = 5 * time.Second
+
 	for {
-		timer := time.NewTimer(cli.keepAliveIdle)
+		var idleTimer <-chan time.Time
+		var timer *time.Timer
+		if keepAliveIdle > 0 {
+			timer = time.NewTimer(keepAliveIdle)
+			idleTimer = timer.C
+		}
+
 		select {
 		case msg, ok := <-readChan:
-			timer.Stop()
-			if ok {
-				go cli.processDataFrame(msg)
-			} else {
+			stopTimer(timer)
+			if !ok {
 				logger.GetLogger().Errorf("connection process is closed")
 				return
 			}
-		case <-timer.C:
-			e := cli.conn.WriteMessage(websocket.PingMessage, nil)
-			if e != nil {
-				logger.GetLogger().Errorf("connection write ping message error: error=[%s]", e)
+			go cli.processDataFrame(msg)
+
+		case <-idleTimer:
+			// Drain a stale pong signal from a previous round.
+			select {
+			case <-pongReceived:
+			default:
+			}
+
+			if err := cli.writeMessage(websocket.PingMessage, nil); err != nil {
+				logger.GetLogger().Errorf("connection write ping message error: error=[%s]", err)
 				return
 			}
-			go func() {
-				select {
-				case <-pongChan:
-					return
-				case <-time.After(5 * time.Second):
-					logger.GetLogger().Errorf("ping time out, connection is closing")
-					cancelLoop()
-					return
-				case <-loopCtx.Done():
+
+			// Wait for pong synchronously so we never race multiple waiters on one channel.
+			select {
+			case <-pongReceived:
+				// alive
+			case msg, ok := <-readChan:
+				// Any inbound traffic means the connection is still up.
+				if !ok {
+					logger.GetLogger().Errorf("connection process is closed")
 					return
 				}
-			}()
+				go cli.processDataFrame(msg)
+			case <-time.After(pingWait):
+				logger.GetLogger().Errorf("ping time out, connection is closing")
+				_ = conn.Close()
+				cancelLoop()
+				return
+			case <-loopCtx.Done():
+				return
+			}
+
 		case <-loopCtx.Done():
-			timer.Stop()
+			stopTimer(timer)
 			return
 		}
 	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func (cli *StreamClient) writeMessage(messageType int, data []byte) error {
+	cli.mutex.Lock()
+	defer cli.mutex.Unlock()
+	if cli.conn == nil {
+		return errors.New("disconnected")
+	}
+	return cli.conn.WriteMessage(messageType, data)
+}
+
+func (cli *StreamClient) writeJSON(v interface{}) error {
+	cli.mutex.Lock()
+	defer cli.mutex.Unlock()
+	if cli.conn == nil {
+		return errors.New("disconnected")
+	}
+	return cli.conn.WriteJSON(v)
 }
 
 func (cli *StreamClient) processDataFrame(rawData []byte) {
@@ -297,17 +357,24 @@ func (cli *StreamClient) reconnect() {
 
 	cli.Close()
 
-	for {
+	// Backoff before retrying to avoid credential reconnect storms / server-side throttling.
+	backoff := 3 * time.Second
+	const maxBackoff = 60 * time.Second
+
+	for attempt := 1; ; attempt++ {
+		time.Sleep(backoff)
 		err := cli.Start(context.Background())
 		if err != nil {
-			logger.GetLogger().Errorf("StreamClient reconnect error. error=[%s]", err)
-			time.Sleep(time.Second * 3)
-		} else {
-			logger.GetLogger().Infof("StreamClient reconnect success")
-			return
+			logger.GetLogger().Errorf("StreamClient reconnect error, attempt=[%d] error=[%s]", attempt, err)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			continue
 		}
+		logger.GetLogger().Infof("StreamClient reconnect success")
+		return
 	}
-
 }
 
 func (cli *StreamClient) GetHandler(stype, stopic string) (handler.IFrameHandler, error) {
@@ -467,11 +534,11 @@ func (cli *StreamClient) SendDataFrameResponse(ctx context.Context, resp *payloa
 		return errors.New("SendDataFrameResponseError_ResponseNil")
 	}
 
-	if cli.conn == nil {
-		logger.GetLogger().Errorf("SendDataFrameResponse error, conn nil, maybe disconnected.")
-		return errors.New("disconnected")
+	if err := cli.writeJSON(resp); err != nil {
+		logger.GetLogger().Errorf("SendDataFrameResponse error, conn nil or write failed, error=[%s]", err)
+		return err
 	}
-	return cli.conn.WriteJSON(resp)
+	return nil
 }
 
 // 通用注册函数

--- a/client/client.go
+++ b/client/client.go
@@ -48,17 +48,23 @@ type StreamClient struct {
 	proxy         string
 	keepAliveIdle time.Duration
 	writeTimeout  time.Duration
+	handlerSlots  chan struct{}
+	maxHandlers   int
 }
 
 type connectionContextKey struct{}
 
-const defaultWriteTimeout = 5 * time.Second
+const (
+	defaultWriteTimeout       = 5 * time.Second
+	defaultMaxPendingHandlers = 100
+)
 
 func NewStreamClient(options ...ClientOption) *StreamClient {
 	lifecycleCtx, cancel := context.WithCancel(context.Background())
 	cli := &StreamClient{
 		keepAliveIdle: 120 * time.Second,
 		writeTimeout:  defaultWriteTimeout,
+		maxHandlers:   defaultMaxPendingHandlers,
 		lifecycleCtx:  lifecycleCtx,
 		cancel:        cancel,
 	}
@@ -81,6 +87,7 @@ func NewStreamClient(options ...ClientOption) *StreamClient {
 
 		option(cli)
 	}
+	cli.handlerSlots = make(chan struct{}, cli.maxHandlers)
 
 	return cli
 }
@@ -137,6 +144,7 @@ func (cli *StreamClient) start(ctx context.Context, expectedLifecycle context.Co
 
 	conn, resp, err := dialer.DialContext(connectCtx, wssUrl, header)
 	if err != nil {
+		closeWebSocketDialResources(conn, resp)
 		return err
 	}
 
@@ -268,7 +276,7 @@ func (cli *StreamClient) processConnection(conn *websocket.Conn, keepAliveIdle t
 				logger.GetLogger().Errorf("connection process is closed")
 				return
 			}
-			go cli.processDataFrameForConnection(conn, msg)
+			cli.dispatchDataFrameForConnectionContext(loopCtx, conn, msg)
 
 		case <-idleTimer:
 			// Drain a stale pong signal from a previous round.
@@ -292,7 +300,7 @@ func (cli *StreamClient) processConnection(conn *websocket.Conn, keepAliveIdle t
 					logger.GetLogger().Errorf("connection process is closed")
 					return
 				}
-				go cli.processDataFrameForConnection(conn, msg)
+				cli.dispatchDataFrameForConnectionContext(loopCtx, conn, msg)
 			case <-time.After(pingWait):
 				logger.GetLogger().Errorf("ping time out, connection is closing")
 				_ = conn.Close()
@@ -389,7 +397,47 @@ func (cli *StreamClient) processDataFrame(rawData []byte) {
 	cli.processDataFrameForConnection(conn, rawData)
 }
 
+func (cli *StreamClient) dispatchDataFrameForConnection(conn *websocket.Conn, rawData []byte) {
+	cli.dispatchDataFrameForConnectionContext(context.Background(), conn, rawData)
+}
+
+func (cli *StreamClient) dispatchDataFrameForConnectionContext(
+	ctx context.Context,
+	conn *websocket.Conn,
+	rawData []byte,
+) {
+	select {
+	case cli.handlerSlots <- struct{}{}:
+		go func() {
+			defer func() {
+				<-cli.handlerSlots
+			}()
+			cli.processDataFrameForConnectionContext(ctx, conn, rawData)
+		}()
+	default:
+		dataFrame, err := payload.DecodeDataFrame(rawData)
+		if err == nil && dataFrame != nil && dataFrame.Type == utils.SubscriptionTypeKSystem {
+			// System frames control connection lifecycle and must not be starved
+			// by slow application handlers. Process them synchronously to keep
+			// control-frame work bounded even if the server sends a burst.
+			cli.processDataFrameForConnectionContext(ctx, conn, rawData)
+			return
+		}
+		logger.GetLogger().Warningf(
+			"connection handler capacity reached, message is left unacknowledged for retry",
+		)
+	}
+}
+
 func (cli *StreamClient) processDataFrameForConnection(conn *websocket.Conn, rawData []byte) {
+	cli.processDataFrameForConnectionContext(context.Background(), conn, rawData)
+}
+
+func (cli *StreamClient) processDataFrameForConnectionContext(
+	ctx context.Context,
+	conn *websocket.Conn,
+	rawData []byte,
+) {
 	defer func() {
 		if err := recover(); err != nil {
 			logger.GetLogger().Errorf("connection processDataFrame panic, error=[%s]", err)
@@ -413,7 +461,10 @@ func (cli *StreamClient) processDataFrameForConnection(conn *websocket.Conn, raw
 		// 没有注册handler，返回404
 		dataAck = payload.NewDataFrameResponse(payload.DataFrameResponseStatusCodeKHandlerNotFound)
 	} else {
-		frameContext := context.WithValue(context.Background(), connectionContextKey{}, conn)
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		frameContext := context.WithValue(ctx, connectionContextKey{}, conn)
 		dataAck, err = frameHandler(frameContext, dataFrame)
 
 		if err != nil && dataAck == nil {
@@ -439,6 +490,21 @@ func (cli *StreamClient) processDataFrameForConnection(conn *websocket.Conn, raw
 
 	if errSend != nil {
 		logger.GetLogger().Errorf("connection processDataFrame send response error: error=[%s]", errSend)
+	}
+	if dataFrame.Type == utils.SubscriptionTypeKSystem && dataFrame.GetTopic() == "disconnect" {
+		// Acknowledge the server command on the source connection before
+		// closing it. Closing inside OnDisconnect makes the ACK write fail and
+		// causes the server to retry an already-processed disconnect command.
+		cli.closeOwnedConnection(conn)
+	}
+}
+
+func closeWebSocketDialResources(conn *websocket.Conn, resp *http.Response) {
+	if conn != nil {
+		_ = conn.Close()
+	}
+	if resp != nil && resp.Body != nil {
+		_ = resp.Body.Close()
 	}
 }
 
@@ -663,11 +729,12 @@ func (cli *StreamClient) GetConnectionEndpoint(ctx context.Context) (*payload.Co
 func (cli *StreamClient) OnDisconnect(ctx context.Context, df *payload.DataFrame) (*payload.DataFrameResponse, error) {
 	logger.GetLogger().Debugf("StreamClient.OnDisconnect")
 
-	if conn, ok := ctx.Value(connectionContextKey{}).(*websocket.Conn); ok {
-		cli.closeOwnedConnection(conn)
-	} else {
-		cli.Close()
+	if ctx != nil {
+		if _, ok := ctx.Value(connectionContextKey{}).(*websocket.Conn); ok {
+			return nil, nil
+		}
 	}
+	cli.Close()
 	return nil, nil
 }
 
@@ -686,6 +753,12 @@ func (cli *StreamClient) OnPing(ctx context.Context, df *payload.DataFrame) (*pa
 
 // 返回正常数据包
 func (cli *StreamClient) SendDataFrameResponse(ctx context.Context, resp *payload.DataFrameResponse) error {
+	if ctx != nil {
+		if conn, ok := ctx.Value(connectionContextKey{}).(*websocket.Conn); ok {
+			return cli.sendDataFrameResponse(conn, resp)
+		}
+	}
+
 	cli.mutex.Lock()
 	conn := cli.conn
 	cli.mutex.Unlock()

--- a/client/client.go
+++ b/client/client.go
@@ -6,8 +6,8 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/open-dingtalk/dingtalk-stream-sdk-go/card"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/url"
 	"sync"
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gorilla/websocket"
 
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/card"
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/chatbot"
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/handler"
 	"github.com/open-dingtalk/dingtalk-stream-sdk-go/logger"
@@ -38,15 +39,24 @@ type StreamClient struct {
 	conn          *websocket.Conn
 	sessionId     string
 	mutex         sync.Mutex
+	writeMutex    sync.Mutex
+	startMutex    sync.Mutex
+	lifecycleCtx  context.Context
+	cancel        context.CancelFunc
 	extras        map[string]string
 	openApiHost   string
 	proxy         string
 	keepAliveIdle time.Duration
 }
 
+type connectionContextKey struct{}
+
 func NewStreamClient(options ...ClientOption) *StreamClient {
+	lifecycleCtx, cancel := context.WithCancel(context.Background())
 	cli := &StreamClient{
 		keepAliveIdle: 120 * time.Second,
+		lifecycleCtx:  lifecycleCtx,
+		cancel:        cancel,
 	}
 
 	defaultOptions := []ClientOption{
@@ -72,18 +82,33 @@ func NewStreamClient(options ...ClientOption) *StreamClient {
 }
 
 func (cli *StreamClient) Start(ctx context.Context) error {
-	if cli.conn != nil {
-		return nil
-	}
+	return cli.start(ctx, nil)
+}
+
+func (cli *StreamClient) start(ctx context.Context, expectedLifecycle context.Context) error {
+	cli.startMutex.Lock()
+	defer cli.startMutex.Unlock()
 
 	cli.mutex.Lock()
-	defer cli.mutex.Unlock()
-
 	if cli.conn != nil {
+		cli.mutex.Unlock()
 		return nil
 	}
+	if expectedLifecycle == nil {
+		if cli.lifecycleCtx == nil || cli.lifecycleCtx.Err() != nil {
+			cli.lifecycleCtx, cli.cancel = context.WithCancel(context.Background())
+		}
+	} else if cli.lifecycleCtx != expectedLifecycle || expectedLifecycle.Err() != nil {
+		cli.mutex.Unlock()
+		return context.Canceled
+	}
+	lifecycleCtx := cli.lifecycleCtx
+	cli.mutex.Unlock()
 
-	endpoint, err := cli.GetConnectionEndpoint(ctx)
+	connectCtx, cancelConnect := contextWithLifecycle(ctx, lifecycleCtx)
+	defer cancelConnect()
+
+	endpoint, err := cli.GetConnectionEndpoint(connectCtx)
 	if err != nil {
 		return err
 	}
@@ -106,40 +131,73 @@ func (cli *StreamClient) Start(ctx context.Context) error {
 		}
 	}
 
-	conn, resp, err := dialer.Dial(wssUrl, header)
+	conn, resp, err := dialer.DialContext(connectCtx, wssUrl, header)
 	if err != nil {
 		return err
 	}
 
 	// 建连失败
-	if resp.StatusCode >= http.StatusBadRequest {
+	if resp != nil && resp.StatusCode >= http.StatusBadRequest {
+		_ = conn.Close()
 		return utils.ErrorFromHttpResponseBody(resp)
 	}
 
+	cli.mutex.Lock()
+	if cli.lifecycleCtx != lifecycleCtx || lifecycleCtx.Err() != nil {
+		cli.mutex.Unlock()
+		_ = conn.Close()
+		return context.Canceled
+	}
+	if cli.conn != nil {
+		cli.mutex.Unlock()
+		_ = conn.Close()
+		return nil
+	}
 	cli.conn = conn
 	cli.sessionId = endpoint.Ticket
+	keepAliveIdle := cli.keepAliveIdle
+	sessionID := cli.sessionId
+	cli.mutex.Unlock()
 
-	logger.GetLogger().Infof("connect success, sessionId=[%s]", cli.sessionId)
+	logger.GetLogger().Infof("connect success, sessionId=[%s]", sessionID)
 
-	go cli.processLoop()
+	go cli.processConnection(conn, keepAliveIdle)
 
 	return nil
 }
 
-func (cli *StreamClient) processLoop() {
-	defer func() {
-		if err := recover(); err != nil {
-			logger.GetLogger().Errorf("connection process panic due to unknown reason, error=[%s]", err)
-		}
-		if cli.AutoReconnect {
-			go cli.reconnect()
+func contextWithLifecycle(ctx, lifecycleCtx context.Context) (context.Context, context.CancelFunc) {
+	connectCtx, cancel := context.WithCancel(ctx)
+	go func() {
+		select {
+		case <-lifecycleCtx.Done():
+			cancel()
+		case <-connectCtx.Done():
 		}
 	}()
+	return connectCtx, cancel
+}
 
+func (cli *StreamClient) processLoop() {
 	cli.mutex.Lock()
 	conn := cli.conn
 	keepAliveIdle := cli.keepAliveIdle
 	cli.mutex.Unlock()
+
+	cli.processConnection(conn, keepAliveIdle)
+}
+
+func (cli *StreamClient) processConnection(conn *websocket.Conn, keepAliveIdle time.Duration) {
+	defer func() {
+		if err := recover(); err != nil {
+			logger.GetLogger().Errorf("connection process panic due to unknown reason, error=[%s]", err)
+		}
+		lifecycleCtx, shouldReconnect := cli.detachConnection(conn)
+		cli.closeConnection(conn)
+		if shouldReconnect {
+			go cli.reconnect(lifecycleCtx)
+		}
+	}()
 
 	if conn == nil {
 		logger.GetLogger().Errorf("connection process connect nil, maybe disconnected.")
@@ -206,7 +264,7 @@ func (cli *StreamClient) processLoop() {
 				logger.GetLogger().Errorf("connection process is closed")
 				return
 			}
-			go cli.processDataFrame(msg)
+			go cli.processDataFrameForConnection(conn, msg)
 
 		case <-idleTimer:
 			// Drain a stale pong signal from a previous round.
@@ -215,7 +273,7 @@ func (cli *StreamClient) processLoop() {
 			default:
 			}
 
-			if err := cli.writeMessage(websocket.PingMessage, nil); err != nil {
+			if err := cli.writeMessageToConnection(conn, websocket.PingMessage, nil); err != nil {
 				logger.GetLogger().Errorf("connection write ping message error: error=[%s]", err)
 				return
 			}
@@ -230,7 +288,7 @@ func (cli *StreamClient) processLoop() {
 					logger.GetLogger().Errorf("connection process is closed")
 					return
 				}
-				go cli.processDataFrame(msg)
+				go cli.processDataFrameForConnection(conn, msg)
 			case <-time.After(pingWait):
 				logger.GetLogger().Errorf("ping time out, connection is closing")
 				_ = conn.Close()
@@ -261,23 +319,49 @@ func stopTimer(timer *time.Timer) {
 
 func (cli *StreamClient) writeMessage(messageType int, data []byte) error {
 	cli.mutex.Lock()
-	defer cli.mutex.Unlock()
-	if cli.conn == nil {
+	conn := cli.conn
+	cli.mutex.Unlock()
+
+	return cli.writeMessageToConnection(conn, messageType, data)
+}
+
+func (cli *StreamClient) writeMessageToConnection(conn *websocket.Conn, messageType int, data []byte) error {
+	if conn == nil {
 		return errors.New("disconnected")
 	}
-	return cli.conn.WriteMessage(messageType, data)
+
+	cli.writeMutex.Lock()
+	defer cli.writeMutex.Unlock()
+	return conn.WriteMessage(messageType, data)
 }
 
 func (cli *StreamClient) writeJSON(v interface{}) error {
 	cli.mutex.Lock()
-	defer cli.mutex.Unlock()
-	if cli.conn == nil {
+	conn := cli.conn
+	cli.mutex.Unlock()
+
+	return cli.writeJSONToConnection(conn, v)
+}
+
+func (cli *StreamClient) writeJSONToConnection(conn *websocket.Conn, v interface{}) error {
+	if conn == nil {
 		return errors.New("disconnected")
 	}
-	return cli.conn.WriteJSON(v)
+
+	cli.writeMutex.Lock()
+	defer cli.writeMutex.Unlock()
+	return conn.WriteJSON(v)
 }
 
 func (cli *StreamClient) processDataFrame(rawData []byte) {
+	cli.mutex.Lock()
+	conn := cli.conn
+	cli.mutex.Unlock()
+
+	cli.processDataFrameForConnection(conn, rawData)
+}
+
+func (cli *StreamClient) processDataFrameForConnection(conn *websocket.Conn, rawData []byte) {
 	defer func() {
 		if err := recover(); err != nil {
 			logger.GetLogger().Errorf("connection processDataFrame panic, error=[%s]", err)
@@ -301,7 +385,8 @@ func (cli *StreamClient) processDataFrame(rawData []byte) {
 		// 没有注册handler，返回404
 		dataAck = payload.NewDataFrameResponse(payload.DataFrameResponseStatusCodeKHandlerNotFound)
 	} else {
-		dataAck, err = frameHandler(context.Background(), dataFrame)
+		frameContext := context.WithValue(context.Background(), connectionContextKey{}, conn)
+		dataAck, err = frameHandler(frameContext, dataFrame)
 
 		if err != nil && dataAck == nil {
 			dataAck = payload.NewErrorDataFrameResponse(err)
@@ -320,7 +405,7 @@ func (cli *StreamClient) processDataFrame(rawData []byte) {
 		dataAck.SetHeader(payload.DataFrameHeaderKContentType, payload.DataFrameContentTypeKJson)
 	}
 
-	errSend := cli.SendDataFrameResponse(context.Background(), dataAck)
+	errSend := cli.sendDataFrameResponse(conn, dataAck)
 	sentBytes, _ := json.Marshal(dataAck)
 	logger.GetLogger().Debugf("[wire] [websocket] local => remote:\n%s", string(sentBytes))
 
@@ -330,41 +415,74 @@ func (cli *StreamClient) processDataFrame(rawData []byte) {
 }
 
 func (cli *StreamClient) Close() {
-	if cli.conn == nil {
-		return
+	cli.mutex.Lock()
+	conn := cli.conn
+	cli.conn = nil
+	cli.sessionId = ""
+	if cli.cancel != nil {
+		cli.cancel()
+	}
+	cli.mutex.Unlock()
+
+	if conn != nil {
+		if err := conn.Close(); err != nil {
+			logger.GetLogger().Errorf("StreamClient close. error=[%s]", err)
+		}
+	}
+}
+
+func (cli *StreamClient) detachConnection(conn *websocket.Conn) (context.Context, bool) {
+	if conn == nil {
+		return nil, false
 	}
 
 	cli.mutex.Lock()
 	defer cli.mutex.Unlock()
-
-	if cli.conn == nil {
-		return
+	if cli.conn != conn {
+		return nil, false
 	}
 
-	if err := cli.conn.Close(); err != nil {
-		logger.GetLogger().Errorf("StreamClient close. error=[%s]", err)
-	}
 	cli.conn = nil
 	cli.sessionId = ""
+	return cli.lifecycleCtx, cli.AutoReconnect
 }
 
-func (cli *StreamClient) reconnect() {
+func (cli *StreamClient) closeConnection(conn *websocket.Conn) {
+	if conn == nil {
+		return
+	}
+	if err := conn.Close(); err != nil {
+		logger.GetLogger().Errorf("StreamClient close. error=[%s]", err)
+	}
+}
+
+func (cli *StreamClient) reconnect(lifecycleCtx context.Context) {
 	defer func() {
 		if err := recover(); err != nil {
 			logger.GetLogger().Errorf("reconect panic due to unknown reason. error=[%s]", err)
 		}
 	}()
 
-	cli.Close()
-
 	// Backoff before retrying to avoid credential reconnect storms / server-side throttling.
 	backoff := 3 * time.Second
 	const maxBackoff = 60 * time.Second
+	random := rand.New(rand.NewSource(time.Now().UnixNano()))
 
 	for attempt := 1; ; attempt++ {
-		time.Sleep(backoff)
-		err := cli.Start(context.Background())
+		jitter := time.Duration(random.Int63n(int64(backoff/5) + 1))
+		timer := time.NewTimer(backoff + jitter)
+		select {
+		case <-timer.C:
+		case <-lifecycleCtx.Done():
+			stopTimer(timer)
+			return
+		}
+
+		err := cli.start(lifecycleCtx, lifecycleCtx)
 		if err != nil {
+			if errors.Is(err, context.Canceled) {
+				return
+			}
 			logger.GetLogger().Errorf("StreamClient reconnect error, attempt=[%d] error=[%s]", attempt, err)
 			backoff *= 2
 			if backoff > maxBackoff {
@@ -517,8 +635,18 @@ func (cli *StreamClient) GetConnectionEndpoint(ctx context.Context) (*payload.Co
 func (cli *StreamClient) OnDisconnect(ctx context.Context, df *payload.DataFrame) (*payload.DataFrameResponse, error) {
 	logger.GetLogger().Debugf("StreamClient.OnDisconnect")
 
-	cli.Close()
+	if conn, ok := ctx.Value(connectionContextKey{}).(*websocket.Conn); ok {
+		cli.closeOwnedConnection(conn)
+	} else {
+		cli.Close()
+	}
 	return nil, nil
+}
+
+func (cli *StreamClient) closeOwnedConnection(conn *websocket.Conn) {
+	// Close only the connection that carried the disconnect frame. Its process
+	// loop decides whether it still owns the client state and should reconnect.
+	cli.closeConnection(conn)
 }
 
 func (cli *StreamClient) OnPing(ctx context.Context, df *payload.DataFrame) (*payload.DataFrameResponse, error) {
@@ -530,11 +658,19 @@ func (cli *StreamClient) OnPing(ctx context.Context, df *payload.DataFrame) (*pa
 
 // 返回正常数据包
 func (cli *StreamClient) SendDataFrameResponse(ctx context.Context, resp *payload.DataFrameResponse) error {
+	cli.mutex.Lock()
+	conn := cli.conn
+	cli.mutex.Unlock()
+
+	return cli.sendDataFrameResponse(conn, resp)
+}
+
+func (cli *StreamClient) sendDataFrameResponse(conn *websocket.Conn, resp *payload.DataFrameResponse) error {
 	if resp == nil {
 		return errors.New("SendDataFrameResponseError_ResponseNil")
 	}
 
-	if err := cli.writeJSON(resp); err != nil {
+	if err := cli.writeJSONToConnection(conn, resp); err != nil {
 		logger.GetLogger().Errorf("SendDataFrameResponse error, conn nil or write failed, error=[%s]", err)
 		return err
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -119,12 +119,12 @@ func TestDingtalkOpenStreamClient_Close(t *testing.T) {
 }
 
 func TestDingtalkOpenStreamClient_reconnect(t *testing.T) {
-	var opens atomic.Int64
+	var opens int64
 	wsEndpoint, closeWS := startEchoWSServer(t)
 	defer closeWS()
 
 	openAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		n := opens.Add(1)
+		n := atomic.AddInt64(&opens, 1)
 		if n == 1 {
 			http.Error(w, `{"code":"Throttling","message":"busy"}`, http.StatusTooManyRequests)
 			return
@@ -145,17 +145,17 @@ func TestDingtalkOpenStreamClient_reconnect(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		cli.reconnect()
+		cli.reconnect(cli.lifecycleCtx)
 		close(done)
 	}()
 
 	select {
 	case <-done:
-	case <-time.After(10 * time.Second):
+	case <-time.After(12 * time.Second):
 		t.Fatal("reconnect did not succeed with backoff")
 	}
 
-	assert.GreaterOrEqual(t, opens.Load(), int64(2))
+	assert.GreaterOrEqual(t, atomic.LoadInt64(&opens), int64(2))
 	assert.NotNil(t, cli.conn)
 	cli.Close()
 }
@@ -355,7 +355,7 @@ func TestProcessLoopMessageDuringPingWaitKeepsAlive(t *testing.T) {
 }
 
 func TestProcessLoopPingPongKeepsConnection(t *testing.T) {
-	var gotPing atomic.Bool
+	var gotPing uint32
 	upgrader := websocket.Upgrader{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -366,7 +366,7 @@ func TestProcessLoopPingPongKeepsConnection(t *testing.T) {
 		defer conn.Close()
 
 		conn.SetPingHandler(func(appData string) error {
-			gotPing.Store(true)
+			atomic.StoreUint32(&gotPing, 1)
 			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
 		})
 
@@ -391,7 +391,9 @@ func TestProcessLoopPingPongKeepsConnection(t *testing.T) {
 		close(done)
 	}()
 
-	require.Eventually(t, gotPing.Load, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return atomic.LoadUint32(&gotPing) == 1
+	}, time.Second, 10*time.Millisecond)
 	require.NoError(t, cli.writeMessage(websocket.TextMessage, []byte(`{"type":"SYSTEM"}`)))
 
 	cli.Close()
@@ -475,8 +477,8 @@ func TestProcessLoopLatePongDoesNotBlockReadPath(t *testing.T) {
 
 func TestProcessLoopConcurrentMessagesAndPing(t *testing.T) {
 	var (
-		gotPing   atomic.Int64
-		gotClient atomic.Int64
+		gotPing   int64
+		gotClient int64
 	)
 	upgrader := websocket.Upgrader{}
 
@@ -488,7 +490,7 @@ func TestProcessLoopConcurrentMessagesAndPing(t *testing.T) {
 		defer conn.Close()
 
 		conn.SetPingHandler(func(appData string) error {
-			gotPing.Add(1)
+			atomic.AddInt64(&gotPing, 1)
 			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
 		})
 
@@ -506,7 +508,7 @@ func TestProcessLoopConcurrentMessagesAndPing(t *testing.T) {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				return
 			}
-			gotClient.Add(1)
+			atomic.AddInt64(&gotClient, 1)
 		}
 	}))
 	defer server.Close()
@@ -539,8 +541,8 @@ func TestProcessLoopConcurrentMessagesAndPing(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Eventually(t, func() bool { return gotPing.Load() >= 1 }, 2*time.Second, 20*time.Millisecond)
-	require.Eventually(t, func() bool { return gotClient.Load() >= 1 }, 2*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool { return atomic.LoadInt64(&gotPing) >= 1 }, 2*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool { return atomic.LoadInt64(&gotClient) >= 1 }, 2*time.Second, 20*time.Millisecond)
 
 	cli.Close()
 	select {
@@ -589,7 +591,7 @@ func TestProcessLoopUnsolicitedPongFlood(t *testing.T) {
 }
 
 func TestProcessLoopAppLevelPingWithKeepAliveDisabled(t *testing.T) {
-	var gotPong atomic.Bool
+	var gotPong uint32
 	upgrader := websocket.Upgrader{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -607,7 +609,7 @@ func TestProcessLoopAppLevelPingWithKeepAliveDisabled(t *testing.T) {
 			return
 		}
 		if strings.Contains(string(data), "app-ping") {
-			gotPong.Store(true)
+			atomic.StoreUint32(&gotPong, 1)
 		}
 		time.Sleep(50 * time.Millisecond)
 	}))
@@ -625,7 +627,9 @@ func TestProcessLoopAppLevelPingWithKeepAliveDisabled(t *testing.T) {
 		close(done)
 	}()
 
-	require.Eventually(t, gotPong.Load, time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool {
+		return atomic.LoadUint32(&gotPong) == 1
+	}, time.Second, 10*time.Millisecond)
 
 	cli.Close()
 	select {
@@ -636,7 +640,7 @@ func TestProcessLoopAppLevelPingWithKeepAliveDisabled(t *testing.T) {
 }
 
 func TestProcessLoopMultiplePingRounds(t *testing.T) {
-	var pingCount atomic.Int64
+	var pingCount int64
 	upgrader := websocket.Upgrader{}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -647,7 +651,7 @@ func TestProcessLoopMultiplePingRounds(t *testing.T) {
 		defer conn.Close()
 
 		conn.SetPingHandler(func(appData string) error {
-			pingCount.Add(1)
+			atomic.AddInt64(&pingCount, 1)
 			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
 		})
 		for {
@@ -671,7 +675,7 @@ func TestProcessLoopMultiplePingRounds(t *testing.T) {
 		close(done)
 	}()
 
-	require.Eventually(t, func() bool { return pingCount.Load() >= 3 }, 2*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool { return atomic.LoadInt64(&pingCount) >= 3 }, 2*time.Second, 20*time.Millisecond)
 
 	cli.Close()
 	select {
@@ -689,7 +693,7 @@ func TestWriteHelpersRejectAfterClose(t *testing.T) {
 }
 
 func TestConcurrentWritesSerialized(t *testing.T) {
-	var reads atomic.Int64
+	var reads int64
 	upgrader := websocket.Upgrader{}
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
@@ -701,7 +705,7 @@ func TestConcurrentWritesSerialized(t *testing.T) {
 			if _, _, err := conn.ReadMessage(); err != nil {
 				return
 			}
-			reads.Add(1)
+			atomic.AddInt64(&reads, 1)
 		}
 	}))
 	defer server.Close()
@@ -723,8 +727,182 @@ func TestConcurrentWritesSerialized(t *testing.T) {
 	}
 	wg.Wait()
 
-	require.Eventually(t, func() bool { return reads.Load() >= 50 }, 2*time.Second, 10*time.Millisecond)
+	require.Eventually(t, func() bool { return atomic.LoadInt64(&reads) >= 50 }, 2*time.Second, 10*time.Millisecond)
 	cli.Close()
+}
+
+func TestCloseDoesNotWaitForBlockedWrite(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	releaseServer := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Do not read: a sufficiently large client write will block until Close
+		// closes the socket.
+		<-releaseServer
+	}))
+	defer server.Close()
+	defer close(releaseServer)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+
+	writeStarted := make(chan struct{})
+	writeDone := make(chan struct{})
+	go func() {
+		close(writeStarted)
+		_ = cli.writeMessage(websocket.BinaryMessage, make([]byte, 64<<20))
+		close(writeDone)
+	}()
+	<-writeStarted
+	time.Sleep(100 * time.Millisecond)
+
+	closeDone := make(chan struct{})
+	go func() {
+		cli.Close()
+		close(closeDone)
+	}()
+
+	select {
+	case <-closeDone:
+	case <-time.After(time.Second):
+		t.Fatal("Close blocked behind an in-flight websocket write")
+	}
+
+	select {
+	case <-writeDone:
+	case <-time.After(time.Second):
+		t.Fatal("blocked websocket write did not exit after Close")
+	}
+}
+
+func TestProcessDataFrameResponseUsesSourceConnection(t *testing.T) {
+	oldMessages := make(chan string, 1)
+	oldConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		defer conn.Close()
+		_, data, err := conn.ReadMessage()
+		if err == nil {
+			oldMessages <- string(data)
+		}
+	})
+
+	newMessages := make(chan string, 1)
+	newConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		defer conn.Close()
+		_, data, err := conn.ReadMessage()
+		if err == nil {
+			newMessages <- string(data)
+		}
+	})
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = newConn
+
+	raw := []byte(`{"headers":{"messageId":"source-conn","topic":"ping"},"type":"SYSTEM","data":"{}"}`)
+	cli.processDataFrameForConnection(oldConn, raw)
+
+	select {
+	case message := <-oldMessages:
+		assert.Contains(t, message, "source-conn")
+	case <-time.After(time.Second):
+		t.Fatal("response was not written to the source connection")
+	}
+
+	select {
+	case message := <-newMessages:
+		t.Fatalf("old frame response leaked to replacement connection: %s", message)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestOldProcessLoopDoesNotDetachReplacementConnection(t *testing.T) {
+	oldConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		_ = conn.Close()
+	})
+	newConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = newConn
+	cli.sessionId = "replacement"
+
+	done := make(chan struct{})
+	go func() {
+		cli.processConnection(oldConn, time.Hour)
+		close(done)
+	}()
+	waitProcessLoopExit(t, done, time.Second)
+
+	cli.mutex.Lock()
+	currentConn := cli.conn
+	sessionID := cli.sessionId
+	cli.mutex.Unlock()
+	assert.Same(t, newConn, currentConn)
+	assert.Equal(t, "replacement", sessionID)
+}
+
+func TestCloseCancelsReconnectBackoff(t *testing.T) {
+	cli := NewStreamClient(
+		WithAppCredential(NewAppCredentialConfig("cid", "csecret")),
+		WithAutoReconnect(true),
+	)
+	lifecycleCtx := cli.lifecycleCtx
+
+	done := make(chan struct{})
+	go func() {
+		cli.reconnect(lifecycleCtx)
+		close(done)
+	}()
+
+	cli.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("reconnect backoff was not canceled by Close")
+	}
+}
+
+func TestOldDisconnectFrameDoesNotCloseReplacementConnection(t *testing.T) {
+	oldConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+	newConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	})
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = newConn
+	cli.sessionId = "replacement"
+
+	ctx := context.WithValue(context.Background(), connectionContextKey{}, oldConn)
+	_, err := cli.OnDisconnect(ctx, &payload.DataFrame{})
+	require.NoError(t, err)
+
+	cli.mutex.Lock()
+	currentConn := cli.conn
+	sessionID := cli.sessionId
+	cli.mutex.Unlock()
+	assert.Same(t, newConn, currentConn)
+	assert.Equal(t, "replacement", sessionID)
 }
 
 func wsURL(httpURL string) string {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -760,7 +760,6 @@ func dialTestWS(t *testing.T) (endpoint string, closeFn func(), conn *websocket.
 	}, c
 }
 
-
 func newTestWebsocketConn(t *testing.T, serverHandler func(*websocket.Conn)) *websocket.Conn {
 	t.Helper()
 

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -782,6 +782,56 @@ func TestCloseDoesNotWaitForBlockedWrite(t *testing.T) {
 	}
 }
 
+func TestBlockedDataWriteDoesNotStallKeepAlive(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	releaseServer := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		// Do not read. The client's large data write fills the socket buffer.
+		<-releaseServer
+	}))
+	defer server.Close()
+	defer close(releaseServer)
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+	cli.writeTimeout = 250 * time.Millisecond
+
+	writeStarted := make(chan struct{})
+	writeDone := make(chan struct{})
+	go func() {
+		close(writeStarted)
+		_ = cli.writeMessage(websocket.BinaryMessage, make([]byte, 64<<20))
+		close(writeDone)
+	}()
+	<-writeStarted
+	time.Sleep(50 * time.Millisecond)
+
+	processDone := make(chan struct{})
+	go func() {
+		cli.processConnection(conn, 20*time.Millisecond)
+		close(processDone)
+	}()
+
+	select {
+	case <-processDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("keepalive stalled behind a blocked application write")
+	}
+	select {
+	case <-writeDone:
+	case <-time.After(time.Second):
+		t.Fatal("blocked application write did not exit after keepalive closed the connection")
+	}
+}
+
 func TestProcessDataFrameResponseUsesSourceConnection(t *testing.T) {
 	oldMessages := make(chan string, 1)
 	oldConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -1,13 +1,23 @@
 package client
 
 import (
+	"context"
+	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/payload"
+	"github.com/open-dingtalk/dingtalk-stream-sdk-go/utils"
 )
 
 /**
@@ -16,13 +26,740 @@ import (
  */
 
 func TestNewDingtalkOpenStreamClient(t *testing.T) {
+	c := NewStreamClient()
+	assert.Equal(t, 120*time.Second, c.keepAliveIdle)
+	assert.True(t, c.AutoReconnect)
+
+	h, err := c.GetHandler(utils.SubscriptionTypeKSystem, "ping")
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
+
+	h, err = c.GetHandler(utils.SubscriptionTypeKSystem, "disconnect")
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
 }
 
 func TestDingtalkOpenStreamClient_Start(t *testing.T) {
+	wsEndpoint, closeWS := startEchoWSServer(t)
+	defer closeWS()
+
+	openAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.Equal(t, utils.GetConnectionEndpointAPIUrl, r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"endpoint": wsEndpoint,
+			"ticket":   "ticket-start-1",
+		})
+	}))
+	defer openAPI.Close()
+
+	cli := NewStreamClient(
+		WithAppCredential(NewAppCredentialConfig("cid", "csecret")),
+		WithOpenApiHost(openAPI.URL),
+		WithAutoReconnect(false),
+		WithKeepAlive(0),
+	)
+	require.NoError(t, cli.Start(context.Background()))
+	require.NotNil(t, cli.conn)
+	require.Equal(t, "ticket-start-1", cli.sessionId)
+
+	// Second Start is a no-op when already connected.
+	require.NoError(t, cli.Start(context.Background()))
+	cli.Close()
+	require.Nil(t, cli.conn)
 }
 
 func TestDingtalkOpenStreamClient_processDataFrame(t *testing.T) {
+	var got atomic.Value
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		got.Store(string(data))
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+
+	raw := []byte(`{"headers":{"messageId":"m-1","topic":"ping"},"type":"SYSTEM","data":"{\"hello\":\"world\"}"}`)
+	cli.processDataFrame(raw)
+
+	require.Eventually(t, func() bool {
+		v, _ := got.Load().(string)
+		return strings.Contains(v, "m-1")
+	}, time.Second, 10*time.Millisecond)
+
+	cli.Close()
 }
+
+func TestDingtalkOpenStreamClient_Close(t *testing.T) {
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.Close() // nil conn is safe
+
+	_, closeFn, conn := dialTestWS(t)
+	defer closeFn()
+
+	cli.conn = conn
+	cli.sessionId = "s1"
+	cli.Close()
+	assert.Nil(t, cli.conn)
+	assert.Equal(t, "", cli.sessionId)
+	cli.Close() // idempotent
+}
+
+func TestDingtalkOpenStreamClient_reconnect(t *testing.T) {
+	var opens atomic.Int64
+	wsEndpoint, closeWS := startEchoWSServer(t)
+	defer closeWS()
+
+	openAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := opens.Add(1)
+		if n == 1 {
+			http.Error(w, `{"code":"Throttling","message":"busy"}`, http.StatusTooManyRequests)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"endpoint": wsEndpoint,
+			"ticket":   fmt.Sprintf("ticket-%d", n),
+		})
+	}))
+	defer openAPI.Close()
+
+	cli := NewStreamClient(
+		WithAppCredential(NewAppCredentialConfig("cid", "csecret")),
+		WithOpenApiHost(openAPI.URL),
+		WithAutoReconnect(false),
+		WithKeepAlive(0),
+	)
+
+	done := make(chan struct{})
+	go func() {
+		cli.reconnect()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("reconnect did not succeed with backoff")
+	}
+
+	assert.GreaterOrEqual(t, opens.Load(), int64(2))
+	assert.NotNil(t, cli.conn)
+	cli.Close()
+}
+
+func TestDingtalkOpenStreamClient_GetHandler(t *testing.T) {
+	cli := NewStreamClient()
+	_, err := cli.GetHandler("UNKNOWN", "x")
+	assert.Error(t, err)
+
+	cli.RegisterCallbackRouter("/custom", func(ctx context.Context, df *payload.DataFrame) (*payload.DataFrameResponse, error) {
+		return payload.NewSuccessDataFrameResponse(), nil
+	})
+	h, err := cli.GetHandler(utils.SubscriptionTypeKCallback, "/custom")
+	assert.NoError(t, err)
+	assert.NotNil(t, h)
+}
+
+func TestDingtalkOpenStreamClient_CheckConfigValid(t *testing.T) {
+	cli := NewStreamClient()
+	assert.Error(t, cli.CheckConfigValid())
+
+	cli = NewStreamClient(WithAppCredential(NewAppCredentialConfig("cid", "sec")))
+	assert.NoError(t, cli.CheckConfigValid())
+
+	cli.RegisterRouter("BADTYPE", "t", func(ctx context.Context, df *payload.DataFrame) (*payload.DataFrameResponse, error) {
+		return nil, nil
+	})
+	assert.Error(t, cli.CheckConfigValid())
+
+	cli = NewStreamClient(WithAppCredential(NewAppCredentialConfig("cid", "sec")))
+	cli.RegisterRouter(utils.SubscriptionTypeKCallback, "nil-handler", nil)
+	assert.Error(t, cli.CheckConfigValid())
+}
+
+func TestDingtalkOpenStreamClient_GetConnectionEndpoint(t *testing.T) {
+	openAPI := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var req payload.ConnectionEndpointRequest
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&req))
+		assert.Equal(t, "cid", req.ClientId)
+		assert.Equal(t, "sec", req.ClientSecret)
+		assert.NotEmpty(t, req.Subscriptions)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"endpoint": "wss://example.dingtalk.com/connect",
+			"ticket":   "ticket-abc",
+		})
+	}))
+	defer openAPI.Close()
+
+	cli := NewStreamClient(
+		WithAppCredential(NewAppCredentialConfig("cid", "sec")),
+		WithOpenApiHost(openAPI.URL),
+	)
+	ep, err := cli.GetConnectionEndpoint(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, "wss://example.dingtalk.com/connect", ep.Endpoint)
+	assert.Equal(t, "ticket-abc", ep.Ticket)
+}
+
+func TestDingtalkOpenStreamClient_OnDisconnect(t *testing.T) {
+	_, closeFn, conn := dialTestWS(t)
+	defer closeFn()
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+	cli.sessionId = "sid"
+
+	_, err := cli.OnDisconnect(context.Background(), &payload.DataFrame{
+		Type: utils.SubscriptionTypeKSystem,
+		Headers: payload.DataFrameHeader{
+			payload.DataFrameHeaderKTopic:     "disconnect",
+			payload.DataFrameHeaderKMessageId: "d1",
+		},
+	})
+	assert.NoError(t, err)
+	assert.Nil(t, cli.conn)
+	assert.Equal(t, "", cli.sessionId)
+}
+
+func TestDingtalkOpenStreamClient_OnPing(t *testing.T) {
+	cli := NewStreamClient()
+	df := &payload.DataFrame{
+		Type: utils.SubscriptionTypeKSystem,
+		Headers: payload.DataFrameHeader{
+			payload.DataFrameHeaderKTopic:     "ping",
+			payload.DataFrameHeaderKMessageId: "ping-1",
+		},
+		Data: `{"ts":1}`,
+	}
+	resp, err := cli.OnPing(context.Background(), df)
+	require.NoError(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, "ping-1", resp.GetHeader(payload.DataFrameHeaderKMessageId))
+	assert.Equal(t, `{"ts":1}`, resp.Data)
+}
+
+func TestDingtalkOpenStreamClient_SendDataFrameResponse(t *testing.T) {
+	cli := NewStreamClient(WithAutoReconnect(false))
+	assert.Error(t, cli.SendDataFrameResponse(context.Background(), nil))
+
+	var got atomic.Value
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		got.Store(string(data))
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+	cli.conn = conn
+
+	resp := payload.NewSuccessDataFrameResponse()
+	resp.SetHeader(payload.DataFrameHeaderKMessageId, "ack-1")
+	require.NoError(t, cli.SendDataFrameResponse(context.Background(), resp))
+	require.Eventually(t, func() bool {
+		v, _ := got.Load().(string)
+		return strings.Contains(v, "ack-1")
+	}, time.Second, 10*time.Millisecond)
+	cli.Close()
+}
+
+func TestDingtalkOpenStreamClient_SendErrorResponse(t *testing.T) {
+	cli := NewStreamClient(WithAutoReconnect(false))
+	assert.EqualError(t, cli.SendDataFrameResponse(context.Background(), nil), "SendDataFrameResponseError_ResponseNil")
+}
+
+func TestStopTimer(t *testing.T) {
+	stopTimer(nil) // no panic
+
+	tm := time.NewTimer(time.Hour)
+	stopTimer(tm)
+
+	tm2 := time.NewTimer(time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
+	stopTimer(tm2) // already fired
+}
+
+func TestProcessLoopMessageDuringPingWaitKeepsAlive(t *testing.T) {
+	// If app traffic arrives while waiting for WS pong, connection should stay up
+	// even when server never replies to ping (old false-timeout risk path).
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.SetPingHandler(func(string) error { return nil }) // no pong
+
+		go func() {
+			time.Sleep(40 * time.Millisecond)
+			_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"headers":{"messageId":"keep","topic":"ping"},"type":"SYSTEM","data":"{}"}`))
+		}()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+	cli.keepAliveIdle = 20 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	// Should still be alive after one idle+ping-wait cycle rescued by inbound message.
+	time.Sleep(200 * time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("processLoop exited too early; inbound message should keep connection alive")
+	default:
+	}
+
+	cli.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("processLoop did not exit after Close")
+	}
+}
+
+func TestProcessLoopPingPongKeepsConnection(t *testing.T) {
+	var gotPing atomic.Bool
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		conn.SetPingHandler(func(appData string) error {
+			gotPing.Store(true)
+			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+		})
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+	cli.keepAliveIdle = 50 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	require.Eventually(t, gotPing.Load, time.Second, 10*time.Millisecond)
+	require.NoError(t, cli.writeMessage(websocket.TextMessage, []byte(`{"type":"SYSTEM"}`)))
+
+	cli.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("processLoop did not exit after Close")
+	}
+}
+
+func TestProcessLoopPingTimeoutClosesConnection(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		conn.SetPingHandler(func(string) error { return nil })
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+	cli.keepAliveIdle = 20 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(6 * time.Second):
+		t.Fatal("processLoop did not exit on ping timeout")
+	}
+}
+
+func TestProcessLoopLatePongDoesNotBlockReadPath(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		_ = conn.WriteControl(websocket.PongMessage, nil, time.Now().Add(time.Second))
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"headers":{"messageId":"1","topic":"ping"},"type":"SYSTEM","data":"{}"}`))
+		time.Sleep(200 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false), WithKeepAlive(0))
+	cli.conn = conn
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processLoop blocked after unsolicited pong")
+	}
+}
+
+func TestProcessLoopConcurrentMessagesAndPing(t *testing.T) {
+	var (
+		gotPing   atomic.Int64
+		gotClient atomic.Int64
+	)
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		conn.SetPingHandler(func(appData string) error {
+			gotPing.Add(1)
+			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+		})
+
+		go func() {
+			for i := 0; i < 50; i++ {
+				msg := fmt.Sprintf(`{"headers":{"messageId":"%d","topic":"ping"},"type":"SYSTEM","data":"{}"}`, i)
+				if err := conn.WriteMessage(websocket.TextMessage, []byte(msg)); err != nil {
+					return
+				}
+				time.Sleep(5 * time.Millisecond)
+			}
+		}()
+
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+			gotClient.Add(1)
+		}
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+	cli.keepAliveIdle = 30 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 20; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = cli.writeJSON(map[string]interface{}{
+				"code": 200,
+				"headers": map[string]string{
+					"messageId": fmt.Sprintf("ack-%d", i),
+				},
+			})
+		}(i)
+	}
+	wg.Wait()
+
+	require.Eventually(t, func() bool { return gotPing.Load() >= 1 }, 2*time.Second, 20*time.Millisecond)
+	require.Eventually(t, func() bool { return gotClient.Load() >= 1 }, 2*time.Second, 20*time.Millisecond)
+
+	cli.Close()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processLoop did not exit after concurrent traffic")
+	}
+}
+
+func TestProcessLoopUnsolicitedPongFlood(t *testing.T) {
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		for i := 0; i < 100; i++ {
+			if err := conn.WriteControl(websocket.PongMessage, nil, time.Now().Add(time.Second)); err != nil {
+				return
+			}
+		}
+		_ = conn.WriteMessage(websocket.TextMessage, []byte(`{"headers":{"messageId":"flood","topic":"ping"},"type":"SYSTEM","data":"{}"}`))
+		time.Sleep(100 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false), WithKeepAlive(0))
+	cli.conn = conn
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("processLoop blocked under unsolicited pong flood")
+	}
+}
+
+func TestProcessLoopAppLevelPingWithKeepAliveDisabled(t *testing.T) {
+	var gotPong atomic.Bool
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		pingFrame := `{"headers":{"messageId":"app-ping","topic":"ping"},"type":"SYSTEM","data":"{}"}`
+		require.NoError(t, conn.WriteMessage(websocket.TextMessage, []byte(pingFrame)))
+
+		_, data, err := conn.ReadMessage()
+		if err != nil {
+			return
+		}
+		if strings.Contains(string(data), "app-ping") {
+			gotPong.Store(true)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false), WithKeepAlive(0))
+	cli.conn = conn
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	require.Eventually(t, gotPong.Load, time.Second, 10*time.Millisecond)
+
+	cli.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("processLoop did not exit")
+	}
+}
+
+func TestProcessLoopMultiplePingRounds(t *testing.T) {
+	var pingCount atomic.Int64
+	upgrader := websocket.Upgrader{}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		conn.SetPingHandler(func(appData string) error {
+			pingCount.Add(1)
+			return conn.WriteControl(websocket.PongMessage, []byte(appData), time.Now().Add(time.Second))
+		})
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+	cli.keepAliveIdle = 40 * time.Millisecond
+
+	done := make(chan struct{})
+	go func() {
+		cli.processLoop()
+		close(done)
+	}()
+
+	require.Eventually(t, func() bool { return pingCount.Load() >= 3 }, 2*time.Second, 20*time.Millisecond)
+
+	cli.Close()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("processLoop did not exit after multiple ping rounds")
+	}
+}
+
+func TestWriteHelpersRejectAfterClose(t *testing.T) {
+	cli := NewStreamClient(WithAutoReconnect(false))
+	require.EqualError(t, cli.writeMessage(websocket.TextMessage, []byte("x")), "disconnected")
+	require.EqualError(t, cli.writeJSON(map[string]string{"a": "b"}), "disconnected")
+	require.EqualError(t, cli.SendDataFrameResponse(context.Background(), payload.NewSuccessDataFrameResponse()), "disconnected")
+}
+
+func TestConcurrentWritesSerialized(t *testing.T) {
+	var reads atomic.Int64
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+			reads.Add(1)
+		}
+	}))
+	defer server.Close()
+
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
+	require.NoError(t, err)
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = conn
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_ = cli.writeJSON(map[string]interface{}{"i": i})
+			_ = cli.writeMessage(websocket.TextMessage, []byte(fmt.Sprintf(`{"n":%d}`, i)))
+		}(i)
+	}
+	wg.Wait()
+
+	require.Eventually(t, func() bool { return reads.Load() >= 50 }, 2*time.Second, 10*time.Millisecond)
+	cli.Close()
+}
+
+func wsURL(httpURL string) string {
+	return "ws" + strings.TrimPrefix(httpURL, "http")
+}
+
+func startEchoWSServer(t *testing.T) (endpoint string, closeFn func()) {
+	t.Helper()
+	upgrader := websocket.Upgrader{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	return wsURL(server.URL), server.Close
+}
+
+func dialTestWS(t *testing.T) (endpoint string, closeFn func(), conn *websocket.Conn) {
+	t.Helper()
+	endpoint, closeServer := startEchoWSServer(t)
+	c, _, err := websocket.DefaultDialer.Dial(endpoint, nil)
+	require.NoError(t, err)
+	return endpoint, func() {
+		_ = c.Close()
+		closeServer()
+	}, c
+}
+
 
 func newTestWebsocketConn(t *testing.T, serverHandler func(*websocket.Conn)) *websocket.Conn {
 	t.Helper()
@@ -37,8 +774,7 @@ func newTestWebsocketConn(t *testing.T, serverHandler func(*websocket.Conn)) *we
 		go serverHandler(conn)
 	}))
 
-	wsURL := "ws" + strings.TrimPrefix(server.URL, "http")
-	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
 	if err != nil {
 		server.Close()
 		t.Fatalf("dial websocket: %v", err)
@@ -128,34 +864,4 @@ func TestDingtalkOpenStreamClient_processLoop_PongHandlerAfterExitDoesNotPanic(t
 			}
 		}()
 	}
-}
-
-func TestDingtalkOpenStreamClient_Close(t *testing.T) {
-
-}
-
-func TestDingtalkOpenStreamClient_reconnect(t *testing.T) {
-}
-
-func TestDingtalkOpenStreamClient_GetHandler(t *testing.T) {
-}
-
-func TestDingtalkOpenStreamClient_CheckConfigValid(t *testing.T) {
-}
-
-func TestDingtalkOpenStreamClient_GetConnectionEndpoint(t *testing.T) {
-
-}
-
-func TestDingtalkOpenStreamClient_OnDisconnect(t *testing.T) {
-
-}
-
-func TestDingtalkOpenStreamClient_OnPing(t *testing.T) {
-}
-
-func TestDingtalkOpenStreamClient_SendDataFrameResponse(t *testing.T) {
-}
-
-func TestDingtalkOpenStreamClient_SendErrorResponse(t *testing.T) {
 }

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -103,6 +104,88 @@ func TestDingtalkOpenStreamClient_processDataFrame(t *testing.T) {
 	cli.Close()
 }
 
+func TestApplicationHandlerConcurrencyIsBounded(t *testing.T) {
+	cli := NewStreamClient(
+		WithAutoReconnect(false),
+		WithMaxPendingHandlers(5),
+	)
+	var handlerCalls int32
+	releaseHandlers := make(chan struct{})
+	cli.RegisterRouter(
+		utils.SubscriptionTypeKCallback,
+		"/slow",
+		func(context.Context, *payload.DataFrame) (*payload.DataFrameResponse, error) {
+			atomic.AddInt32(&handlerCalls, 1)
+			<-releaseHandlers
+			return payload.NewSuccessDataFrameResponse(), nil
+		},
+	)
+
+	for i := 0; i < 20; i++ {
+		raw := []byte(fmt.Sprintf(
+			`{"headers":{"messageId":"m-%d","topic":"/slow"},"type":"CALLBACK","data":"{}"}`,
+			i,
+		))
+		cli.dispatchDataFrameForConnection(nil, raw)
+	}
+
+	require.Eventually(t, func() bool {
+		return atomic.LoadInt32(&handlerCalls) == 5
+	}, time.Second, 10*time.Millisecond)
+	assert.Equal(t, int32(5), atomic.LoadInt32(&handlerCalls))
+
+	close(releaseHandlers)
+	require.Eventually(t, func() bool {
+		return len(cli.handlerSlots) == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestApplicationHandlerContextIsCanceledWithConnection(t *testing.T) {
+	cli := NewStreamClient(
+		WithAutoReconnect(false),
+		WithMaxPendingHandlers(1),
+	)
+	handlerStarted := make(chan struct{})
+	handlerCanceled := make(chan struct{})
+	cli.RegisterRouter(
+		utils.SubscriptionTypeKCallback,
+		"/cancel-aware",
+		func(ctx context.Context, _ *payload.DataFrame) (*payload.DataFrameResponse, error) {
+			close(handlerStarted)
+			<-ctx.Done()
+			close(handlerCanceled)
+			return nil, ctx.Err()
+		},
+	)
+
+	connectionCtx, cancelConnection := context.WithCancel(context.Background())
+	raw := []byte(
+		`{"headers":{"messageId":"cancel-1","topic":"/cancel-aware"},"type":"CALLBACK","data":"{}"}`,
+	)
+	cli.dispatchDataFrameForConnectionContext(connectionCtx, nil, raw)
+
+	select {
+	case <-handlerStarted:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not start")
+	}
+	cancelConnection()
+	select {
+	case <-handlerCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("handler did not observe connection cancellation")
+	}
+	require.Eventually(t, func() bool {
+		return len(cli.handlerSlots) == 0
+	}, time.Second, 10*time.Millisecond)
+}
+
+func TestCloseWebSocketDialResourcesClosesHandshakeResponse(t *testing.T) {
+	body := &trackingReadCloser{Reader: strings.NewReader("handshake failed")}
+	closeWebSocketDialResources(nil, &http.Response{Body: body})
+	assert.True(t, body.closed)
+}
+
 func TestDingtalkOpenStreamClient_Close(t *testing.T) {
 	cli := NewStreamClient(WithAutoReconnect(false))
 	cli.Close() // nil conn is safe
@@ -116,6 +199,16 @@ func TestDingtalkOpenStreamClient_Close(t *testing.T) {
 	assert.Nil(t, cli.conn)
 	assert.Equal(t, "", cli.sessionId)
 	cli.Close() // idempotent
+}
+
+type trackingReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (body *trackingReadCloser) Close() error {
+	body.closed = true
+	return nil
 }
 
 func TestDingtalkOpenStreamClient_reconnect(t *testing.T) {
@@ -784,35 +877,50 @@ func TestCloseDoesNotWaitForBlockedWrite(t *testing.T) {
 
 func TestBlockedDataWriteDoesNotStallKeepAlive(t *testing.T) {
 	upgrader := websocket.Upgrader{}
-	releaseServer := make(chan struct{})
+	pingReceived := make(chan struct{}, 1)
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
 		if err != nil {
 			return
 		}
 		defer conn.Close()
-		// Do not read. The client's large data write fills the socket buffer.
-		<-releaseServer
+		conn.SetPingHandler(func(appData string) error {
+			select {
+			case pingReceived <- struct{}{}:
+			default:
+			}
+			return conn.WriteControl(
+				websocket.PongMessage,
+				[]byte(appData),
+				time.Now().Add(time.Second),
+			)
+		})
+		for {
+			if _, _, err := conn.ReadMessage(); err != nil {
+				return
+			}
+		}
 	}))
 	defer server.Close()
-	defer close(releaseServer)
 
 	conn, _, err := websocket.DefaultDialer.Dial(wsURL(server.URL), nil)
 	require.NoError(t, err)
+	defer conn.Close()
 
 	cli := NewStreamClient(WithAutoReconnect(false))
 	cli.conn = conn
-	cli.writeTimeout = 250 * time.Millisecond
+	cli.writeTimeout = time.Second
 
-	writeStarted := make(chan struct{})
-	writeDone := make(chan struct{})
-	go func() {
-		close(writeStarted)
-		_ = cli.writeMessage(websocket.BinaryMessage, make([]byte, 64<<20))
-		close(writeDone)
+	// Holding writeMutex models an application data write that is blocked while
+	// owning the SDK's data-write lock. Keepalive control frames must not need
+	// that lock.
+	cli.writeMutex.Lock()
+	writeLockHeld := true
+	defer func() {
+		if writeLockHeld {
+			cli.writeMutex.Unlock()
+		}
 	}()
-	<-writeStarted
-	time.Sleep(50 * time.Millisecond)
 
 	processDone := make(chan struct{})
 	go func() {
@@ -821,14 +929,19 @@ func TestBlockedDataWriteDoesNotStallKeepAlive(t *testing.T) {
 	}()
 
 	select {
-	case <-processDone:
-	case <-time.After(2 * time.Second):
-		t.Fatal("keepalive stalled behind a blocked application write")
-	}
-	select {
-	case <-writeDone:
+	case <-pingReceived:
 	case <-time.After(time.Second):
-		t.Fatal("blocked application write did not exit after keepalive closed the connection")
+		t.Fatal("keepalive ping stalled behind the application write lock")
+	}
+
+	cli.writeMutex.Unlock()
+	writeLockHeld = false
+	require.NoError(t, conn.Close())
+
+	select {
+	case <-processDone:
+	case <-time.After(time.Second):
+		t.Fatal("connection processor did not exit after the connection closed")
 	}
 }
 
@@ -867,6 +980,47 @@ func TestProcessDataFrameResponseUsesSourceConnection(t *testing.T) {
 	select {
 	case message := <-newMessages:
 		t.Fatalf("old frame response leaked to replacement connection: %s", message)
+	case <-time.After(100 * time.Millisecond):
+	}
+}
+
+func TestSendDataFrameResponseUsesContextConnection(t *testing.T) {
+	sourceMessages := make(chan string, 1)
+	sourceConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		defer conn.Close()
+		_, data, err := conn.ReadMessage()
+		if err == nil {
+			sourceMessages <- string(data)
+		}
+	})
+
+	replacementMessages := make(chan string, 1)
+	replacementConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
+		defer conn.Close()
+		_, data, err := conn.ReadMessage()
+		if err == nil {
+			replacementMessages <- string(data)
+		}
+	})
+
+	cli := NewStreamClient(WithAutoReconnect(false))
+	cli.conn = replacementConn
+	ctx := context.WithValue(context.Background(), connectionContextKey{}, sourceConn)
+	resp := payload.NewSuccessDataFrameResponse()
+	resp.SetHeader(payload.DataFrameHeaderKMessageId, "context-source")
+
+	require.NoError(t, cli.SendDataFrameResponse(ctx, resp))
+
+	select {
+	case message := <-sourceMessages:
+		assert.Contains(t, message, "context-source")
+	case <-time.After(time.Second):
+		t.Fatal("context-bound response was not written to the source connection")
+	}
+
+	select {
+	case message := <-replacementMessages:
+		t.Fatalf("context-bound response leaked to replacement connection: %s", message)
 	case <-time.After(100 * time.Millisecond):
 	}
 }
@@ -923,13 +1077,16 @@ func TestCloseCancelsReconnectBackoff(t *testing.T) {
 	}
 }
 
-func TestOldDisconnectFrameDoesNotCloseReplacementConnection(t *testing.T) {
+func TestDisconnectAckUsesSourceBeforeClosingWithoutClosingReplacement(t *testing.T) {
+	ackReceived := make(chan []byte, 1)
+	sourceClosed := make(chan struct{})
 	oldConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
-		for {
-			if _, _, err := conn.ReadMessage(); err != nil {
-				return
-			}
+		_, message, err := conn.ReadMessage()
+		if err == nil {
+			ackReceived <- message
 		}
+		_, _, _ = conn.ReadMessage()
+		close(sourceClosed)
 	})
 	newConn := newTestWebsocketConn(t, func(conn *websocket.Conn) {
 		for {
@@ -943,9 +1100,24 @@ func TestOldDisconnectFrameDoesNotCloseReplacementConnection(t *testing.T) {
 	cli.conn = newConn
 	cli.sessionId = "replacement"
 
-	ctx := context.WithValue(context.Background(), connectionContextKey{}, oldConn)
-	_, err := cli.OnDisconnect(ctx, &payload.DataFrame{})
-	require.NoError(t, err)
+	raw := []byte(
+		`{"headers":{"messageId":"disconnect-1","topic":"disconnect"},"type":"SYSTEM","data":"{}"}`,
+	)
+	cli.processDataFrameForConnection(oldConn, raw)
+
+	select {
+	case ack := <-ackReceived:
+		var response payload.DataFrameResponse
+		require.NoError(t, json.Unmarshal(ack, &response))
+		assert.Equal(t, "disconnect-1", response.GetHeader(payload.DataFrameHeaderKMessageId))
+	case <-time.After(time.Second):
+		t.Fatal("disconnect ACK was not written to the source connection")
+	}
+	select {
+	case <-sourceClosed:
+	case <-time.After(time.Second):
+		t.Fatal("source connection was not closed after disconnect ACK")
+	}
 
 	cli.mutex.Lock()
 	currentConn := cli.conn

--- a/client/config.go
+++ b/client/config.go
@@ -41,7 +41,7 @@ type UserAgentConfig struct {
 
 func NewDingtalkGoSDKUserAgent() *UserAgentConfig {
 	return &UserAgentConfig{
-		UserAgent: "dingtalk-sdk-go/v0.9.1",
+		UserAgent: "dingtalk-sdk-go/v0.9.2",
 	}
 }
 

--- a/client/option.go
+++ b/client/option.go
@@ -30,11 +30,19 @@ func WithSubscription(stype, stopic string, frameHandler handler.IFrameHandler) 
 	}
 }
 
+// WithKeepAlive sets idle duration before the client sends a websocket ping.
+// Pass 0 (or negative) to disable client-side websocket ping and rely on
+// application-level system/ping only. Values in (0, 3s) are raised to 3s.
 func WithKeepAlive(keepAliveIdle time.Duration) ClientOption {
 	return func(client *StreamClient) {
-		if keepAliveIdle >= 3*time.Second {
-			client.keepAliveIdle = keepAliveIdle
+		if keepAliveIdle <= 0 {
+			client.keepAliveIdle = 0
+			return
 		}
+		if keepAliveIdle < 3*time.Second {
+			keepAliveIdle = 3 * time.Second
+		}
+		client.keepAliveIdle = keepAliveIdle
 	}
 }
 

--- a/client/option.go
+++ b/client/option.go
@@ -46,6 +46,18 @@ func WithKeepAlive(keepAliveIdle time.Duration) ClientOption {
 	}
 }
 
+// WithMaxPendingHandlers bounds concurrently running EVENT and CALLBACK
+// handlers. When the limit is reached, new application frames are left
+// unacknowledged so the server can retry them. Non-positive values use the
+// default limit of 100.
+func WithMaxPendingHandlers(maxHandlers int) ClientOption {
+	return func(client *StreamClient) {
+		if maxHandlers > 0 {
+			client.maxHandlers = maxHandlers
+		}
+	}
+}
+
 func WithUserAgent(ua *UserAgentConfig) ClientOption {
 	return func(c *StreamClient) {
 		if ua.Valid() != nil {

--- a/client/option_test.go
+++ b/client/option_test.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -37,4 +38,30 @@ func TestWithUserAgent(t *testing.T) {
 	op := WithUserAgent(NewDingtalkGoSDKUserAgent())
 	c := NewStreamClient(op)
 	assert.NotNil(t, c.UserAgent)
+	assert.Equal(t, "dingtalk-sdk-go/v0.9.2", c.UserAgent.UserAgent)
+}
+
+func TestWithKeepAlive(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		c := NewStreamClient()
+		assert.Equal(t, 120*time.Second, c.keepAliveIdle)
+	})
+
+	t.Run("disable", func(t *testing.T) {
+		c := NewStreamClient(WithKeepAlive(0))
+		assert.Equal(t, time.Duration(0), c.keepAliveIdle)
+
+		c = NewStreamClient(WithKeepAlive(-time.Second))
+		assert.Equal(t, time.Duration(0), c.keepAliveIdle)
+	})
+
+	t.Run("raise short interval", func(t *testing.T) {
+		c := NewStreamClient(WithKeepAlive(time.Second))
+		assert.Equal(t, 3*time.Second, c.keepAliveIdle)
+	})
+
+	t.Run("custom", func(t *testing.T) {
+		c := NewStreamClient(WithKeepAlive(30 * time.Second))
+		assert.Equal(t, 30*time.Second, c.keepAliveIdle)
+	})
 }


### PR DESCRIPTION
## Summary

在 upstream `main`（已包含 #34）之上，补齐 Stream 长连接、消息处理和资源生命周期问题：

- 使用 context 管理连接退出，消除 #27/#32 的 `send on closed channel` 根因，并保留 panic 防护
- keepalive ping 使用 `WriteControl`，业务写增加 deadline，避免写锁阻塞导致假超时
- pong 非阻塞、重连指数退避且可由 `Close()` 及时取消
- EVENT/CALLBACK handler 默认最多并发 100 个，可用 `WithMaxPendingHandlers` 配置
- handler context 随来源连接取消；ACK 始终写回来源连接
- disconnect 先在来源连接 ACK，再关闭旧连接，不会误关替代连接
- WebSocket 握手失败时关闭 response body/残留连接
- 补齐 #30 的 `robotCode` 映射
- CI 增加 Go 1.18/1.20/1.26 与 race 检查

## Related issues

Closes #28.
Closes #32.
Refs #27.
Closes #30.

## Validation

- `GOTOOLCHAIN=go1.18.10 go test ./...`
- `GOTOOLCHAIN=go1.20.14 go test ./...`
- `GOTOOLCHAIN=go1.26.1 go test -race ./...`
- `GOTOOLCHAIN=go1.26.1 go vet ./...`
- 关键连接生命周期、来源 ACK、keepalive 与并发上限用例连续 100 轮
- `gofmt`、`actionlint`、`git diff --check`
